### PR TITLE
Conditionally enable Vue devtools plugin during development

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,21 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, type PluginOption } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
+const plugins: PluginOption[] = [vue()]
+
+if (process.env.NODE_ENV !== 'production') {
+  plugins.push(vueDevTools())
+}
+
 export default defineConfig({
   base: '/deckbuilder/',
   // vueDevTools() is currently incompatibile with Storybook.
   // Comment it out if Storybook is crashing.
-  plugins: [vue(), vueDevTools()],
+  plugins,
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary
- update the Vite configuration to only include the Vue devtools plugin during non-production builds
- ensure production builds in CI no longer attempt to access localStorage

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69181078d3d883299a74295511092d8e)